### PR TITLE
Install `typing` conditionally

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=['url_summary'],
     install_requires=[
         'six',
-        'typing',
+        'typing;python_version<"3.5"',
     ],
     long_description=read('README.rst'),
     classifiers=[


### PR DESCRIPTION
Updated `typing`'s install requirement in setup.py to only install it in older python 3 versions as described in https://pypi.org/project/typing/, as this is a builtin library since python 3.5.

Installing `typing` when it's also available as a builtin library causes issues in some situations as they are no longer in sync, so it shouldn't be required if it can be avoided.